### PR TITLE
Affiliation multiple : sauts de ligne

### DIFF
--- a/macros_article.html
+++ b/macros_article.html
@@ -729,9 +729,13 @@
 					<a href="[#IDPERSON|makeurlwithid]">[#PRENOM] <span class="family-name">[#NOMFAMILLE]</span></a>
 				</h3>
 				<IF COND="[#DESCRIPTION]">
-					<p class="article__person-description">
-						[#DESCRIPTION|removetags("p")]
-					</p>
+					<IF COND="false SNE [#DESCRIPTION|strpos('<br')]">
+						[#DESCRIPTION]
+					<ELSEIF COND="false SNE [#DESCRIPTION|strpos('<p')]" />
+						[#DESCRIPTION|replace('class="description','class="article__person-description')]
+					<ELSE />
+						<p class="article__person-description">[#DESCRIPTION]</p>
+					</IF>
 				</IF>
 				<IF COND="[#COURRIEL]">
 					<a class="article__person-email" href="mailto:[#COURRIEL]">[#COURRIEL]</a>


### PR DESCRIPTION
Compatibilité avec Métopes version 2.3.
affichage correct des sauts de ligne séparant les différentes
affiliation d'un même auteur

## Jusqu' à la version 2.2 de Métopes  
 - on rajoute un saut de ligne dans XmlMind  
 Le xml OE produit se présente ainsi :  
```
<affiliation>Université d’Oxford<tei:lb xmlns:tei="http://www.tei-c.org/ns/1.0"/>Université de la Sorbonne Nouvelle<tei:lb xmlns:tei="http://www.tei-c.org/ns/1.0"/>Grihl</affiliation>
```
  - après chargement dans Lodel, on obtient le html suivant (tel que stocké dans le champs description de la table entities_auteurs) :
```
<p class="description">Université d’Oxford<br/>Université de la Sorbonne Nouvelle<br/>Grihl</p>
``` 

## A partir de la version 2.3 de Métopes
   - la balise affiliation devient répétable (l'ajout de line break entre 2 balises n'est visiblement pas conservé par l'export xmlmind =>OE)
    Le xml OE produit se présente ainsi :
```
<affiliation>Université d’Oxford</affiliation><affiliation>Université de la Sorbonne Nouvelle</affiliation><affiliation>Grihl</affiliation>  
```
  - après chargement dans Lodel, on obtient le html suivant :
```
<p class="description">Université d’Oxford</p><p class="description">Université de la Sorbonne Nouvelle</p><p class="description">Grihl</p>