### PR TITLE
Add pagination block on top of "All issues" page

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -176,6 +176,8 @@ h7, .heading7 {color: @color-2;}
 
 
 .link-to-issues {color:@color-3;.font-size(1.6);}
+#main-content .section-header-container {flex:35%;}
+#main-content .section-header-container + nav.pagination-container {margin-top:25px;margin-right:15px;}
 
 .main-menu .publi-number {.font-size(1.6);}
 .map .publi-number {.font-size(1.8);}
@@ -624,6 +626,9 @@ p.encadre + p.encadre {margin-top: 0;}
 
 .separateur {text-align:center;}
 
+@media (max-width: @screen-xs) {
+	#main-content .section-header-container + nav.pagination-container {margin:10px 0 0 15px;flex:65%;}
+}
 @media (max-width: @screen-sm) {
 	.article__text-contents {padding: 0;}
 	.side-actualites__section {padding:0 30px 30px;}
@@ -681,9 +686,8 @@ p.encadre + p.encadre {margin-top: 0;}
 	.toc__contents--docannexes .toc__title span {.font-size(1.3);} 
 	.toc__contents--docannexes .toc__title{.font-size(1.3);} 
 	.article_text__section--buttons {padding-left:5px;}	
+	#main-content .section-header-container {margin-left:15px;}
 }
-
-
 @media (min-width: @screen-sm) {
 	.article_text__section {padding-right:30px;}
 	.side-actualites__section {margin-left:-15px;}

--- a/macros_nav.html
+++ b/macros_nav.html
@@ -205,7 +205,7 @@
 
 /**
  * Pagination des résultats d'une boucle sur plusieurs pages.
- * Doit être appelée dans la balise <AFTER>.
+ * Doit être appelée dans la balise <BEFORE> ou <AFTER>.
  * D'après PRINT_PAGE_SCALE : https://github.com/OpenEdition/lodel/blob/6604180dade14bf0b63fc395d3718f3dc1dd027e/share/macros/macros.html#L66
  */
 <DEFMACRO NAME="NAV_PAGE_SCALE">

--- a/macros_numeros.html
+++ b/macros_numeros.html
@@ -18,10 +18,14 @@
  */
 <DEFMACRO NAME="NUMEROS_MAIN">
 	<LET VAR="NUMEROS_PAR_PAGE">10</LET>
+	<div class="row">
 	<FUNC NAME="BASE_SECTION_HEADER" TITLE="[@TOUS_LES_NUMEROS]" />
 	<LOOP NAME="numeros_main" TABLE="publications" WHERE="type = 'numero' AND paraitre != 1 AND idparent = '[#ID]'" ORDER="rank DESC" SPLIT="[#NUMEROS_PAR_PAGE]">
 		<BEFORE>
-			<div id="issues" class="issues">
+			<IF COND="[#NBRESULTS] GT [#NUMEROS_PAR_PAGE]">
+				<MACRO NAME="NAV_PAGE_SCALE" />
+			</IF>
+			</div><div id="issues" class="issues">
 		</BEFORE>
 		<DO>
 			<MACRO NAME="NUMEROS_ISSUE" />


### PR DESCRIPTION
Suite à plusieurs remarques de lecteurs de la revue Arabesques, nous avons ajouté une pagination en haut de page permettant de naviguer plus facilement dans les pages de la liste *Tous les numéros*.
Cela nous semble effectivement plus pratique quand cette liste commence à être touffue.
On peut voir ce que cela donne à l'adresse de la revue :
[Arabesques](https://publications-prairial.fr/arabesques)  puis cliquer sur le lien *Tous les numéros*.
