### PR TITLE
Set max number of issues in menu via an option

### DIFF
--- a/macros_menu.html
+++ b/macros_menu.html
@@ -181,11 +181,13 @@
  * @param {string} [filtre] - Filtre passé dans le WHERE de la requête.
  */
 <DEFFUNC NAME="MENU_ISSUES_ITEMS" REQUIRED="titre_section, id_collection" OPTIONAL="filtre">
+	<LET VAR="limit"><IF COND="[#OPTIONS.EXTRA.MAX_ISSUES]">[#OPTIONS.EXTRA.MAX_ISSUES]<ELSE />999999</IF></LET>
 	<LOOP NAME="menu_issues_items" 
 		TABLE="publications"
 		SELECT="id, numero, titre, altertitre, periode, datepubli, datepublipapier"
 		WHERE="idparent = '[#ID_COLLECTION]' [#FILTRE]"
-		ORDER="rank DESC">
+		ORDER="rank DESC"
+		LIMIT="[#LIMIT]">
 		<BEFORE>
 			<section class="main-menu__section main-menu__section--issues">
 				<h2 class="main-menu__section-title">[#TITRE_SECTION]</h2>


### PR DESCRIPTION
Sur plusieurs des sites de Prairial, il nous a été demandé de limiter, pour des raisons différentes, de manière temporaire ou non, le nombre de numéros affichés dans le menu de gauche. Il me parait donc approprié de proposer cela en tant qu'option.
En plus du patch, il est nécessaire d'ajouter l'option max_issues 

- identifier : max_issues
- titre : Nombre maximum de numéros affichés dans le menu

par l'interface d'administration (Modèle éditorial/Administrer les options) : ajouter dans le groupe Extra.  

ou sur le serveur en ajoutant la ligne suivante au script [options_extra_me_upgrade.php](https://github.com/edinum/lodel-options-extra) : 
  `  'max_issues' => ['title'=>'Nombre maximum de numéros affichés dans le menu', 'type'=>'tinytext', 'edition'=>'editable', 'editionparams' => '', 'defaultvalue' => '', 'value' => ''],`
