### PR TITLE
Anchor issues

### DIFF
--- a/macros_article.html
+++ b/macros_article.html
@@ -138,7 +138,7 @@
 		<FUNC NAME="BASE_LISTER_PERSONNES" TYPE="auteur" WRAP_ID="article-author" WRAP_CLASS="article__author" HREF="#authors-infos"/>
 
 		<!--[ Traducteurs ]-->
-		<FUNC NAME="BASE_LISTER_PERSONNES" TYPE="traducteur" WRAP_ID="article-translator" WRAP_CLASS="article__author" PREPEND="[@TRADUCTION_DE] " HREF="#article__translators-infos" />
+		<FUNC NAME="BASE_LISTER_PERSONNES" TYPE="traducteur" WRAP_ID="article-translator" WRAP_CLASS="article__author" PREPEND="[@TRADUCTION_DE] " HREF="#translators-infos" />
 
 		<!--[ DOI ]-->
 		<IF COND="[%PREFIXEDOI] AND [#TYPE] EQ 'article'">

--- a/macros_entrees.html
+++ b/macros_entrees.html
@@ -27,7 +27,7 @@
  * Titre h1 du type d'index.
  */
 <DEFMACRO NAME="ENTREES_TITLE">
-	<h1 class="main-title entrees__title">
+	<h1 id="indexes-alphabet" class="main-title entrees__title">
 		[@INDEX]&#160;| <span class="entrees__type"><IF COND="[#TYPE.ALTERTITLE:#SITELANG]">[#TYPE.ALTERTITLE:#SITELANG]<ELSE/>[#TYPE.TITLE]</IF></span>
 	</h1>
 </DEFMACRO>

--- a/macros_personnes.html
+++ b/macros_personnes.html
@@ -22,7 +22,7 @@
  * Titre h1 de la page (type de personnes).
  */
 <DEFMACRO NAME="PERSONNES_TITLE">
-	<h1 class="main-title personnes__title">
+	<h1 id="indexes-alphabet" class="main-title personnes__title">
 		[@INDEX]&#160;| <span class="personnes__type"><IF COND="[#TYPE.ALTERTITLE:#SITELANG]">[#TYPE.ALTERTITLE:#SITELANG]<ELSE/>[#TYPE.TITLE]</IF></span>
 	</h1>
 </DEFMACRO>


### PR DESCRIPTION
Un patch corrige le lien entre le nom du traducteur sous le titre vers le bloc des traducteurs au bas de l'article.
L'autre corrige le problème signalé par SylDanh #87